### PR TITLE
[3章] アサーションの基本一覧

### DIFF
--- a/XCTest_Playground.xcodeproj/project.pbxproj
+++ b/XCTest_Playground.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4014732D2CB5677600FA494B /* XCTest_PlaygroundUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */; };
 		4014732F2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */; };
 		401473422CB56C9500FA494B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401473412CB56C9500FA494B /* Calculator.swift */; };
+		401473442CB56EF100FA494B /* BasicAssertionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401473432CB56EF100FA494B /* BasicAssertionTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,7 @@
 		4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITests.swift; sourceTree = "<group>"; };
 		4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		401473412CB56C9500FA494B /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
+		401473432CB56EF100FA494B /* BasicAssertionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicAssertionTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				401473222CB5677600FA494B /* CalculatorTest.swift */,
+				401473432CB56EF100FA494B /* BasicAssertionTest.swift */,
 			);
 			path = XCTest_PlaygroundTests;
 			sourceTree = "<group>";
@@ -278,6 +281,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				401473442CB56EF100FA494B /* BasicAssertionTest.swift in Sources */,
 				401473232CB5677600FA494B /* CalculatorTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XCTest_PlaygroundTests/BasicAssertionTest.swift
+++ b/XCTest_PlaygroundTests/BasicAssertionTest.swift
@@ -1,0 +1,64 @@
+//
+//  BasicAssertionTest.swift
+//  XCTest_Playground
+//
+//  Created by MasayaNakakuki on 2024/10/08.
+//
+
+import XCTest
+
+struct Dog: Equatable {
+    var name: String
+    var age: Int
+}
+
+class BasicAssertionTest: XCTestCase {
+
+    private let string = "Hello"
+    private let notNumber = Int("Hello")
+    private let number = Int("334")
+    private let dog1 = Dog(name: "一郎", age: 51)
+    private let dog2 = Dog(name: "翔平", age: 30)
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // Boolを判定する (p.64)
+    func testHasPrefix() {
+        XCTAssertTrue(string.hasPrefix("He"), "stringがHeから始まること、ヨシ")
+        XCTAssertFalse(string.isEmpty, "stringがEmptyじゃないこと、ヨシ")
+    }
+
+    // nilを判定する (p.65)
+    func testNumberValidation() {
+        XCTAssertNil(notNumber, "notNumberはnilであること、ヨシ")
+        XCTAssertNotNil(number, "numberはnilじゃないこと、ヨシ")
+    }
+
+    // 等値性を判定する (p.65)
+    func testEqual() {
+        XCTAssertEqual(string, "Hello", "stringがHelloであること、ヨシ")
+        XCTAssertNotEqual(string, "Goodbye", "stringがGoodbyeではないこと、ヨシ")
+    }
+
+    // Equtable準拠 (p.66)
+    func testEqutable() {
+        XCTAssertNotEqual(dog1, dog2, "それぞれ違うDogであること、ヨシ")
+
+    }
+
+    // 大小判定 (p.69)
+    func testCompareNumber() {
+        XCTAssertGreaterThan(20, 10, "20は10より大きいこと、ヨシ")
+        XCTAssertGreaterThanOrEqual(20, 10)
+        XCTAssertGreaterThanOrEqual(334, 334, "GreaterThanOrEqualは等くてもOK、ヨシ")
+        XCTAssertLessThan(10, 20, "10は20より小さい、ヨシ")
+        XCTAssertLessThanOrEqual(334, 334, "LessThanOrEqualは等くてもOK、ヨシ")
+    }
+
+}

--- a/XCTest_PlaygroundTests/CalculatorTest.swift
+++ b/XCTest_PlaygroundTests/CalculatorTest.swift
@@ -17,7 +17,7 @@ class CalculatorTests: XCTestCase {
         self.calculator = Calculator()
     }
 
-    override class func tearDown() {
+    override func tearDown() {
         super.tearDown()
     }
 


### PR DESCRIPTION
``` Swift
import XCTest

struct Dog: Equatable {
    var name: String
    var age: Int
}

class BasicAssertionTest: XCTestCase {

    private let string = "Hello"
    private let notNumber = Int("Hello")
    private let number = Int("334")
    private let dog1 = Dog(name: "一郎", age: 51)
    private let dog2 = Dog(name: "翔平", age: 30)

    override func setUp() {
        super.setUp()
    }

    override func tearDown() {
        super.tearDown()
    }

    // Boolを判定する (p.64)
    func testHasPrefix() {
        XCTAssertTrue(string.hasPrefix("He"), "stringがHeから始まること、ヨシ")
        XCTAssertFalse(string.isEmpty, "stringがEmptyじゃないこと、ヨシ")
    }

    // nilを判定する (p.65)
    func testNumberValidation() {
        XCTAssertNil(notNumber, "notNumberはnilであること、ヨシ")
        XCTAssertNotNil(number, "numberはnilじゃないこと、ヨシ")
    }

    // 等値性を判定する (p.65)
    func testEqual() {
        XCTAssertEqual(string, "Hello", "stringがHelloであること、ヨシ")
        XCTAssertNotEqual(string, "Goodbye", "stringがGoodbyeではないこと、ヨシ")
    }

    // Equtable準拠 (p.66)
    func testEqutable() {
        XCTAssertNotEqual(dog1, dog2, "それぞれ違うDogであること、ヨシ")

    }

    // 大小判定 (p.69)
    func testCompareNumber() {
        XCTAssertGreaterThan(20, 10, "20は10より大きいこと、ヨシ")
        XCTAssertGreaterThanOrEqual(20, 10)
        XCTAssertGreaterThanOrEqual(334, 334, "GreaterThanOrEqualは等くてもOK、ヨシ")
        XCTAssertLessThan(10, 20, "10は20より小さい、ヨシ")
        XCTAssertLessThanOrEqual(334, 334, "LessThanOrEqualは等くてもOK、ヨシ")
    }

}
```