### PR TITLE
[3章] 例外処理系のテスト

### DIFF
--- a/XCTest_Playground.xcodeproj/project.pbxproj
+++ b/XCTest_Playground.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		4014732D2CB5677600FA494B /* XCTest_PlaygroundUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */; };
 		4014732F2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */; };
 		401473422CB56C9500FA494B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401473412CB56C9500FA494B /* Calculator.swift */; };
+		401473482CB573EE00FA494B /* Failure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401473472CB573EE00FA494B /* Failure.swift */; };
+		4014734A2CB5742100FA494B /* FailureTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401473492CB5742100FA494B /* FailureTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +48,8 @@
 		4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITests.swift; sourceTree = "<group>"; };
 		4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		401473412CB56C9500FA494B /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
+		401473472CB573EE00FA494B /* Failure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Failure.swift; sourceTree = "<group>"; };
+		401473492CB5742100FA494B /* FailureTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailureTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				401473222CB5677600FA494B /* CalculatorTest.swift */,
+				401473492CB5742100FA494B /* FailureTest.swift */,
 			);
 			path = XCTest_PlaygroundTests;
 			sourceTree = "<group>";
@@ -134,6 +139,7 @@
 			isa = PBXGroup;
 			children = (
 				401473412CB56C9500FA494B /* Calculator.swift */,
+				401473472CB573EE00FA494B /* Failure.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -268,6 +274,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				401473482CB573EE00FA494B /* Failure.swift in Sources */,
 				401473142CB5677400FA494B /* ContentView.swift in Sources */,
 				401473122CB5677400FA494B /* XCTest_PlaygroundApp.swift in Sources */,
 				401473422CB56C9500FA494B /* Calculator.swift in Sources */,
@@ -278,6 +285,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4014734A2CB5742100FA494B /* FailureTest.swift in Sources */,
 				401473232CB5677600FA494B /* CalculatorTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XCTest_Playground/Models/Failure.swift
+++ b/XCTest_Playground/Models/Failure.swift
@@ -1,0 +1,37 @@
+//
+//  Failure.swift
+//  XCTest_Playground
+//
+//  Created by MasayaNakakuki on 2024/10/08.
+//
+
+import Foundation
+
+enum DownloadError: Error, Equatable {
+    case connectionError
+    case unknownError(code: Int)
+}
+
+struct SystemError: Error {
+    let message: String
+}
+
+final class Failure {
+    func executeClosure(_ condition: Bool, handler: () -> Void) {
+        if condition {
+            handler()
+        }
+    }
+
+    func downloadContent(connectionFailed: Bool) throws {
+        if connectionFailed {
+            throw DownloadError.connectionError
+        } else {
+            throw DownloadError.unknownError(code: 334)
+        }
+    }
+
+    func throwSystemError() throws {
+        throw SystemError(message: "memory access error")
+    }
+}

--- a/XCTest_PlaygroundTests/FailureTest.swift
+++ b/XCTest_PlaygroundTests/FailureTest.swift
@@ -1,0 +1,60 @@
+//
+//  FailureTest.swift
+//  XCTest_Playground
+//
+//  Created by MasayaNakakuki on 2024/10/08.
+//
+
+import XCTest
+@testable import XCTest_Playground
+
+class FailureTest: XCTestCase {
+
+    var failure: Failure!
+    let string1: String = "Hello"
+    let string2: String? = "Hello"
+
+    override func setUp() {
+        super.setUp()
+        self.failure = Failure()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // 意図的に失敗させる (p.70)
+    func testClosure() {
+        failure.executeClosure(false) {
+            XCTFail("conditionがfalseの場合はクロージャが呼び出されないこと、ヨシ")
+        }
+
+    }
+
+    // 例外を判定する (p.71)
+    func testThrowsError() {
+        XCTAssertThrowsError(try failure.downloadContent(connectionFailed: true)) { (error: Error) -> Void in
+            XCTAssertEqual(error as? DownloadError, DownloadError.connectionError, "connectionFailed = trueの時はconnectionErrorが返されること、ヨシ")
+        }
+    }
+
+    // 例外検証その２ (p.73)
+    func testSystemError() {
+        XCTAssertThrowsError(try failure.throwSystemError()) { (error: Error) -> Void in
+            // throwされた例外errorがSystemErrorにキャストできることを検証
+            guard let systemError = error as? SystemError else {
+                XCTFail()
+                return
+            }
+
+            // messageプロパティの値が期待値と一致するか検証
+            XCTAssertEqual(systemError.message, "memory access error", "SystemErrorのmessageがmemory access errorになること、ヨシ")
+        }
+    }
+
+    // 型Tと型Optional<T>は比較できる (p.75)
+    func testOptionalComparison() {
+        XCTAssertEqual(string1, string2, "型Tと型Optional<T>は比較できる、ヨシ")
+
+    }
+}


### PR DESCRIPTION
``` Swift
import XCTest
@testable import XCTest_Playground

class FailureTest: XCTestCase {

    var failure: Failure!
    let string1: String = "Hello"
    let string2: String? = "Hello"

    override func setUp() {
        super.setUp()
        self.failure = Failure()
    }

    override func tearDown() {
        super.tearDown()
    }

    // 意図的に失敗させる (p.70)
    func testClosure() {
        failure.executeClosure(false) {
            XCTFail("conditionがfalseの場合はクロージャが呼び出されないこと、ヨシ")
        }

    }

    // 例外を判定する (p.71)
    func testThrowsError() {
        XCTAssertThrowsError(try failure.downloadContent(connectionFailed: true)) { (error: Error) -> Void in
            XCTAssertEqual(error as? DownloadError, DownloadError.connectionError, "connectionFailed = trueの時はconnectionErrorが返されること、ヨシ")
        }
    }

    // 例外検証その２ (p.73)
    func testSystemError() {
        XCTAssertThrowsError(try failure.throwSystemError()) { (error: Error) -> Void in
            // throwされた例外errorがSystemErrorにキャストできることを検証
            guard let systemError = error as? SystemError else {
                XCTFail()
                return
            }

            // messageプロパティの値が期待値と一致するか検証
            XCTAssertEqual(systemError.message, "memory access error", "SystemErrorのmessageがmemory access errorになること、ヨシ")
        }
    }

    // 型Tと型Optional<T>は比較できる (p.75)
    func testOptionalComparison() {
        XCTAssertEqual(string1, string2, "型Tと型Optional<T>は比較できる、ヨシ")

    }
}
```