### PR TITLE
[3章] オリジナルアサーション

### DIFF
--- a/XCTest_Playground.xcodeproj/project.pbxproj
+++ b/XCTest_Playground.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4014732D2CB5677600FA494B /* XCTest_PlaygroundUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */; };
 		4014732F2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */; };
 		401473422CB56C9500FA494B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401473412CB56C9500FA494B /* Calculator.swift */; };
+		40D3BA972CB7603C00DC4BE4 /* OriginalAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D3BA962CB7603C00DC4BE4 /* OriginalAssertion.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,7 @@
 		4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITests.swift; sourceTree = "<group>"; };
 		4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		401473412CB56C9500FA494B /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
+		40D3BA962CB7603C00DC4BE4 /* OriginalAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalAssertion.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				401473222CB5677600FA494B /* CalculatorTest.swift */,
+				40D3BA962CB7603C00DC4BE4 /* OriginalAssertion.swift */,
 			);
 			path = XCTest_PlaygroundTests;
 			sourceTree = "<group>";
@@ -287,6 +290,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				401473232CB5677600FA494B /* CalculatorTest.swift in Sources */,
+				40D3BA972CB7603C00DC4BE4 /* OriginalAssertion.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XCTest_PlaygroundTests/OriginalAssertion.swift
+++ b/XCTest_PlaygroundTests/OriginalAssertion.swift
@@ -1,0 +1,20 @@
+//
+//  OriginalAssertion.swift
+//  XCTest_Playground
+//
+//  Created by MasayaNakakuki on 2024/10/10.
+//
+
+import XCTest
+
+// 独自のAssertion (p.79)
+func assertEmpty(_ string: String, file: StaticString = #file, line: UInt = #line) {
+    XCTAssert(string.isEmpty, "\"\(string)\" is not empty)", file: file, line: line)
+}
+
+class OriginalAssertionTests: XCTestCase {
+    func testAssertEmpty() {
+        let string = "Hello" // 失敗させる場合 (assertEmptyのfileとline引数を使うことでこっちにエラーが表示されるようになる)
+        assertEmpty(string)
+    }
+}


### PR DESCRIPTION
``` Swift
import XCTest

// 独自のAssertion (p.79)
func assertEmpty(_ string: String, file: StaticString = #file, line: UInt = #line) {
    XCTAssert(string.isEmpty, "\"\(string)\" is not empty)", file: file, line: line)
}

class OriginalAssertionTests: XCTestCase {
    func testAssertEmpty() {
        let string = "Hello" // 失敗させる場合 (assertEmptyのfileとline引数を使うことでこっちにエラーが表示されるようになる)
        assertEmpty(string)
    }
}
```