### PR TITLE
[3章] RunActivityのサンプル

### DIFF
--- a/XCTest_Playground.xcodeproj/project.pbxproj
+++ b/XCTest_Playground.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4014732D2CB5677600FA494B /* XCTest_PlaygroundUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */; };
 		4014732F2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */; };
 		401473422CB56C9500FA494B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401473412CB56C9500FA494B /* Calculator.swift */; };
+		40D3BA9B2CB764F400DC4BE4 /* XCTContextTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D3BA9A2CB764F400DC4BE4 /* XCTContextTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,7 @@
 		4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITests.swift; sourceTree = "<group>"; };
 		4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		401473412CB56C9500FA494B /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
+		40D3BA9A2CB764F400DC4BE4 /* XCTContextTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTContextTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				401473222CB5677600FA494B /* CalculatorTest.swift */,
+				40D3BA9A2CB764F400DC4BE4 /* XCTContextTest.swift */,
 			);
 			path = XCTest_PlaygroundTests;
 			sourceTree = "<group>";
@@ -287,6 +290,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				401473232CB5677600FA494B /* CalculatorTest.swift in Sources */,
+				40D3BA9B2CB764F400DC4BE4 /* XCTContextTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XCTest_PlaygroundTests/XCTContextTest.swift
+++ b/XCTest_PlaygroundTests/XCTContextTest.swift
@@ -1,0 +1,47 @@
+//
+//  XCTContextTest.swift
+//  XCTest_Playground
+//
+//  Created by MasayaNakakuki on 2024/10/10.
+//
+
+import XCTest
+
+func safeDivision(_ x: Int, _ y: Int) -> Int? {
+    if y == 0 {
+        return nil
+    } else {
+        return x / y
+    }
+}
+
+// RunActivityのお勉強 (p.85)
+class XCTContextTest: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testSafeDivision() {
+        // 通常の割り算
+        XCTAssertEqual(safeDivision(6, 3), 2, "6 / 3 = 2であること、ヨシ")
+
+        // 0除算
+        XCTAssertNil(safeDivision(334, 0), "0で割る時はnilになること、ヨシ")
+    }
+
+    // RunActivityを使用する場合
+    func testSafeDivisionRunActivity() {
+        XCTContext.runActivity(named: "通常の割り算") { _ in
+            XCTAssertEqual(safeDivision(6, 3), 2, "6 / 3 = 2であること、ヨシ")
+        }
+
+        XCTContext.runActivity(named: "0除算") { _ in
+            XCTAssertNil(safeDivision(334, 0), "0で割る時はnilになること、ヨシ")
+        }
+
+    }
+}


### PR DESCRIPTION
``` Swift
import XCTest

func safeDivision(_ x: Int, _ y: Int) -> Int? {
    if y == 0 {
        return nil
    } else {
        return x / y
    }
}

// RunActivityのお勉強 (p.85)
class XCTContextTest: XCTestCase {
    override func setUp() {
        super.setUp()
    }

    override func tearDown() {
        super.tearDown()
    }

    func testSafeDivision() {
        // 通常の割り算
        XCTAssertEqual(safeDivision(6, 3), 2, "6 / 3 = 2であること、ヨシ")

        // 0除算
        XCTAssertNil(safeDivision(334, 0), "0で割る時はnilになること、ヨシ")
    }

    // RunActivityを使用する場合
    func testSafeDivisionRunActivity() {
        XCTContext.runActivity(named: "通常の割り算") { _ in
            XCTAssertEqual(safeDivision(6, 3), 2, "6 / 3 = 2であること、ヨシ")
        }

        XCTContext.runActivity(named: "0除算") { _ in
            XCTAssertNil(safeDivision(334, 0), "0で割る時はnilになること、ヨシ")
        }

    }
}
```