### PR TITLE
[3章] XCTestExpectationサンプル

### DIFF
--- a/XCTest_Playground.xcodeproj/project.pbxproj
+++ b/XCTest_Playground.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4014732D2CB5677600FA494B /* XCTest_PlaygroundUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */; };
 		4014732F2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */; };
 		401473422CB56C9500FA494B /* Calculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401473412CB56C9500FA494B /* Calculator.swift */; };
+		40D3BA9D2CB7678A00DC4BE4 /* XCTestExpectationSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D3BA9C2CB7678A00DC4BE4 /* XCTestExpectationSample.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,7 @@
 		4014732C2CB5677600FA494B /* XCTest_PlaygroundUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITests.swift; sourceTree = "<group>"; };
 		4014732E2CB5677600FA494B /* XCTest_PlaygroundUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest_PlaygroundUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		401473412CB56C9500FA494B /* Calculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculator.swift; sourceTree = "<group>"; };
+		40D3BA9C2CB7678A00DC4BE4 /* XCTestExpectationSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestExpectationSample.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				401473222CB5677600FA494B /* CalculatorTest.swift */,
+				40D3BA9C2CB7678A00DC4BE4 /* XCTestExpectationSample.swift */,
 			);
 			path = XCTest_PlaygroundTests;
 			sourceTree = "<group>";
@@ -287,6 +290,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				401473232CB5677600FA494B /* CalculatorTest.swift in Sources */,
+				40D3BA9D2CB7678A00DC4BE4 /* XCTestExpectationSample.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XCTest_PlaygroundTests/XCTestExpectationSample.swift
+++ b/XCTest_PlaygroundTests/XCTestExpectationSample.swift
@@ -1,0 +1,59 @@
+//
+//  XCTestExpectationSample.swift
+//  XCTest_Playground
+//
+//  Created by MasayaNakakuki on 2024/10/10.
+//
+
+import XCTest
+
+func echo(message: String, _ handler: @escaping(String) -> Void) {
+    DispatchQueue.global().async {
+        // 3秒待機
+        Thread.sleep(forTimeInterval: 3)
+
+        // 末尾に!をつけてコールバック呼び出し
+        DispatchQueue.main.async {
+            handler("\(message)!")
+        }
+    }
+}
+
+class XCTestExpectationSample: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // 間違ったコード
+    func testEcho() {
+        echo(message: "Hello") { (message) in
+            XCTAssertEqual(message, "Hello!") // 末尾に!がついていることを検証
+        }
+    }
+
+    // 間違ったコード2
+    func testEcho2() {
+        echo(message: "Hello") { (message) in
+            XCTFail()
+        }
+    }
+
+    // 正しいテスト
+    func testEcho3() {
+        let exp: XCTestExpectation = expectation(description: "Wait for Finish")
+
+        echo(message: "Hello") { (message) in
+            XCTAssertEqual(message, "Hello!")
+
+            // expの待機を解除
+            exp.fulfill()
+        }
+
+        // expに対してfulfill()が呼び出されるまで待機 (5秒でタイムアウト)
+        wait(for: [exp], timeout: 5)
+    }
+}


### PR DESCRIPTION
``` Swift
import XCTest

func echo(message: String, _ handler: @escaping(String) -> Void) {
    DispatchQueue.global().async {
        // 3秒待機
        Thread.sleep(forTimeInterval: 3)

        // 末尾に!をつけてコールバック呼び出し
        DispatchQueue.main.async {
            handler("\(message)!")
        }
    }
}

class XCTestExpectationSample: XCTestCase {
    override func setUp() {
        super.setUp()
    }

    override func tearDown() {
        super.tearDown()
    }

    // 間違ったコード
    func testEcho() {
        echo(message: "Hello") { (message) in
            XCTAssertEqual(message, "Hello!") // 末尾に!がついていることを検証
        }
    }

    // 間違ったコード2
    func testEcho2() {
        echo(message: "Hello") { (message) in
            XCTFail()
        }
    }

    // 正しいテスト
    func testEcho3() {
        let exp: XCTestExpectation = expectation(description: "Wait for Finish")

        echo(message: "Hello") { (message) in
            XCTAssertEqual(message, "Hello!")

            // expの待機を解除
            exp.fulfill()
        }

        // expに対してfulfill()が呼び出されるまで待機 (5秒でタイムアウト)
        wait(for: [exp], timeout: 5)
    }
}
```